### PR TITLE
add openAI and twitter bot

### DIFF
--- a/Social_Media_Bots/OpenAIBot/QueryOpenAI.py
+++ b/Social_Media_Bots/OpenAIBot/QueryOpenAI.py
@@ -1,0 +1,30 @@
+import openai
+import configparser
+
+config = configparser.RawConfigParser()
+config.read('config.ini')
+openai.api_key = config.get('dev', 'api_key')
+
+def query(question, instructions):
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        temperature=0,
+        n=1,
+        messages=[
+            {
+                "role": "system",
+                "content": instructions
+            },
+            {
+                "role": "user",
+                "content": question
+            },
+        ],
+    )
+    print(response["choices"][0]["message"]["content"])
+
+
+if __name__ == "__main__":
+    instructions = input("Enter instructions for chatgpt model: ")
+    question = input("Enter question for chatgpt model: ")
+    query(question, instructions)

--- a/Social_Media_Bots/OpenAIBot/README.md
+++ b/Social_Media_Bots/OpenAIBot/README.md
@@ -1,0 +1,20 @@
+# Chat bot to interact with openAI
+
+## Setup
+Goto https://platform.openai.com/, create account and generate API key. Place the api key in config.ini file.
+
+#### Example 1:
+```
+python3 QueryOpenAI.py
+Enter instructions for chatgpt model: You will be provided with a message, and your task is to respond using emojis only.
+Enter question for chatgpt model: how are you doing?
+👋😊👍
+```
+
+#### Example 2:
+```
+python3 QueryOpenAI.py
+Enter instructions for chatgpt model: Respond in less than 100 words
+Enter question for chatgpt model: Make a story on cat
+Once upon a time, in a small village, there lived a mischievous cat named Whiskers. Whiskers was known for his playful nature and his ability to bring joy to everyone he encountered. One day, he stumbled upon a lost kitten named Mittens. Whiskers took Mittens under his wing and taught her the ways of the village. Together, they embarked on countless adventures, exploring the woods, chasing butterflies, and making friends with other animals. Whiskers and Mittens became inseparable, spreading happiness wherever they went. Their bond reminded everyone of the power of friendship and the joy that can be found in the simplest of moments.
+```

--- a/Social_Media_Bots/OpenAIBot/config.ini
+++ b/Social_Media_Bots/OpenAIBot/config.ini
@@ -1,0 +1,2 @@
+[dev]
+api_key=

--- a/Social_Media_Bots/TwitterBot/BotUsingTweepy/README.md
+++ b/Social_Media_Bots/TwitterBot/BotUsingTweepy/README.md
@@ -1,0 +1,7 @@
+## Twitter bot to post status updates to twitter, search for hashtags
+
+#### This code allows one to publish new status on twitter.
+
+#### Twitter v2 API free tier doesn't allow one to search for tweets. Only paid plans support that.
+
+#### To use the program, generate tokens on your twitter account and update the config.ini file with the secrets.

--- a/Social_Media_Bots/TwitterBot/BotUsingTweepy/config.ini
+++ b/Social_Media_Bots/TwitterBot/BotUsingTweepy/config.ini
@@ -1,0 +1,6 @@
+[dev]
+consumer_key=
+consumer_secret=
+access_token=
+access_token_secret=
+bearer_token=

--- a/Social_Media_Bots/TwitterBot/BotUsingTweepy/scraper.py
+++ b/Social_Media_Bots/TwitterBot/BotUsingTweepy/scraper.py
@@ -1,0 +1,50 @@
+import tweepy
+import configparser
+import pandas as pd
+import time
+
+OUTPUT_DIR = "data"
+
+config = configparser.RawConfigParser()
+config.read('config.ini')
+consumer_key = config.get('dev', 'consumer_key')
+consumer_secret = config.get('dev', 'consumer_secret')
+access_token = config.get('dev', 'access_token')
+access_token_secret = config.get('dev', 'access_token_secret')
+bearer_token = config.get('dev', 'bearer_token')
+
+client = tweepy.Client(
+    consumer_key=consumer_key,
+    consumer_secret=consumer_secret,
+    access_token=access_token,
+    access_token_secret=access_token_secret,
+    bearer_token=bearer_token,
+    wait_on_rate_limit=True
+)
+
+def tweet(text):
+    response = client.create_tweet(text=text)
+    print(response)
+
+def get_tweets_by_query(text_query, count, lang='en', result_type='mixed', filter_rt=True):
+    try:
+        # Filter retweets
+        if filter_rt:
+            text_query = text_query + " -filter:retweets"
+
+        tweets = client.search_recent_tweets(query=text_query, user_auth=True)
+
+        tweets_list = [[tweet.created_at, tweet.id, tweet.full_text] for tweet in tweets]
+
+        tweets_df = pd.DataFrame(tweets_list,columns=['Datetime', 'Tweet Id', 'Text'])
+
+        filename = text_query.replace(' ', '_')
+
+        tweets_df.to_csv(f'{OUTPUT_DIR}/{filename}.txt', sep=',', index = False)
+    except BaseException as e:
+        print('failed to get tweets,',str(e))
+
+
+tweet("hello world!")
+
+get_tweets_by_query("chatgpt", 10)


### PR DESCRIPTION
Adds bot for:
1. OpenAI to perform actions using CLI. This can be used to automate search queries to openai.
2. Twitter to post tweets. With API v2, free tier only allows one to tweet and to search tweets, one needs to upgrade to paid plan.